### PR TITLE
Fix expressions in contributing.org

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -8,7 +8,7 @@ Here is how software developers can contribute to ~leaf.el~.
 
 ** Copyright assignments
 Fill below form and send <assign@gnu.org>.
-You also find more information at org-mode [[https://orgmode.org/worg/org-contribute.html#copyright-issues][contribution page]].
+You also find more information at org-mode's [[https://orgmode.org/worg/org-contribute.html#copyright-issues][contribution page]].
 
 #+begin_example
 Please email the following information to assign@gnu.org, and we
@@ -21,7 +21,7 @@ REQUEST: SEND FORM FOR PAST AND FUTURE CHANGES
 
 [What is the name of the program or package you're contributing to?]
 
-  leaf.el, which plan to include ELPA; Emacs official package archive.
+  leaf.el, which is planned to be included in ELPA, the Emacs official package archive.
 
 [Did you copy any files or text written by someone else in these changes?
 Even if that material is free software, we need to know about it.]


### PR DESCRIPTION
Most significant problem is that it says "leaf.el, which plan to *include* ELPA."
No! That's opposite!

And what plans to do is the author. Not the thing leaf.el. So it's
better to correct to the passitve.


## Description

<!-- Please write a description of your PR -->

## Checklist
<!-- Please confirm with `x` -->
- [ ] I've read [CONTRIBUTING.org](https://github.com/conao3/leaf.el/blob/master/CONTRIBUTING.org).
  - [ ] I've assign FSF.
  - [ ] The leaf.el after my changed pass all testcases by `make test`.
  - [ ] My changed elisp code byte-compiled cleanly.
  - [ ] I've added testcases related to my PR.
  - [ ] I've fixed README related the my added testcases.